### PR TITLE
Add webmaxru WebMCP skill to Developer Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Inspector](https://webmcpinspector.com/) - Online inspector for testing and debugging WebMCP tool registrations.
 - [WordLift AI Readiness Audit](https://audit.wordlift.io/) - Scan your site for WebMCP / agent readiness.
 - [WebMCP Cheat Sheet](https://www.webfuse.com/webmcp-cheat-sheet) - Quick-reference cheat sheet for declarative and imperative APIs, schemas, and common patterns.
+- [webmaxru/agent-skills: WebMCP](https://github.com/webmaxru/agent-skills/tree/main/skills/webmcp) - Agent skill for shipping and debugging `navigator.modelContext` integrations in existing JavaScript or TypeScript apps, with guidance for declarative forms, tool schemas, and preview validation.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the WebMCP skill from webmaxru/agent-skills
- place it in Developer Tools & Utilities because it helps teams ship and debug navigator.modelContext integrations in existing apps

## Why this fits
The resource is focused on practical implementation guidance for declarative forms, tool schemas, validation, and preview troubleshooting.