### PR TITLE
Add isainative.dev to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 ### Community Demos
 
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
+- [isainative.dev](https://isainative.dev/) - Audit public GitHub repositories for AI coding readiness. Exposing both declarative and imperative WebMCP tools.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.


### PR DESCRIPTION
## Summary
- add the isainative.dev WebMCP-enabled demo application to Community Demos

## Why this fits
The site is a live community demo that exposes both declarative and imperative WebMCP tools for a concrete workflow: auditing public GitHub repositories for AI coding readiness.