### PR TITLE
feat: add webmcp-sdk, agentpay-mcp SDK and x402 payment demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The official companion library suite for WebMCP.
 - [webmcp-react](https://github.com/MCPCat/webmcp-react) - React hooks for exposing typed tools via `navigator.modelContext`. Zod-first schemas, built-in polyfill, SSR-compatible (Next.js/Remix), and StrictMode-safe with reactive execution state tracking.
 - [webmcp-kit](https://github.com/victorhuangwq/webmcp-kit) - Zod-typed tool definitions, ideal for modern TypeScript/React apps.
 - [WebMCP Widget Library](https://webmcp.dev) - One-line `<script>` tag for quick demos and prototyping. [GitHub](https://github.com/jasonjmcghee/WebMCP).
+- [webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk) - W3C WebMCP developer toolkit with x402 payment support. Make any website agent-ready with `navigator.modelContext`. Includes TypeScript types, tool helpers, and x402 payment integration for Base.
+- [agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp) - Non-custodial x402 payment layer for AI agents (v4.0.0). Handles HTTP 402 Payment Required automatically — agent wallet signs on Base and retries. Patent Pending.
 
 ---
 
@@ -109,6 +111,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
+- [AgentPay x402 Payment Demo](https://googlechromelabs.github.io/webmcp-tools/demos/x402-payment/) - AI agent makes x402 micropayments (HTTP 402 Payment Required) through `navigator.modelContext`. Wallet auto-signs on Base and retries. Shows both declarative + imperative tool patterns. [Code](https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/x402-payment)
 
 ---
 


### PR DESCRIPTION
## What's added

### 📦 Libraries, SDKs & Polyfills

Two new entries under **Standalone Libraries**:

- **[webmcp-sdk](https://github.com/up2itnow0822/webmcp-sdk)** — W3C WebMCP developer toolkit with x402 payment support. Make any website agent-ready with `navigator.modelContext`. Includes TypeScript types, tool helpers, and x402 payment integration for Base.

- **[agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp)** (v4.0.0) — Non-custodial x402 payment layer for AI agents. Handles HTTP 402 Payment Required automatically — agent wallet signs on Base and retries. Patent Pending.

### 🎮 Demos & Example Projects

- **[AgentPay x402 Payment Demo](https://googlechromelabs.github.io/webmcp-tools/demos/x402-payment/)** — AI agent makes x402 micropayments (HTTP 402 Payment Required) through `navigator.modelContext`. Wallet auto-signs on Base and retries. Shows both declarative + imperative tool patterns.

## Why it's useful

x402 is the emerging standard for **AI agent micropayments** on the web — HTTP 402 gets a real implementation. This demo + SDK pair make it easy for other developers to add paid API access to their WebMCP tools without centralised payment infrastructure.

## Links verified

- https://github.com/up2itnow0822/webmcp-sdk ✅
- https://www.npmjs.com/package/agentpay-mcp ✅  
- https://googlechromelabs.github.io/webmcp-tools/demos/x402-payment/ (pending PR merge into GoogleChromeLabs/webmcp-tools#96)
- https://github.com/GoogleChromeLabs/webmcp-tools/tree/main/demos/x402-payment ✅