### PR TITLE
Add webmcp-next to Standalone Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The official companion library suite for WebMCP.
 
 - [webmcp-react](https://github.com/MCPCat/webmcp-react) - React hooks for exposing typed tools via `navigator.modelContext`. Zod-first schemas, built-in polyfill, SSR-compatible (Next.js/Remix), and StrictMode-safe with reactive execution state tracking.
 - [webmcp-kit](https://github.com/victorhuangwq/webmcp-kit) - Zod-typed tool definitions, ideal for modern TypeScript/React apps.
+- [webmcp-next](https://github.com/dankelleher/next-webmcp) - Next.js plugin that auto-exposes API routes and server actions as WebMCP tools and resources. Zero-config `withWebMCP()` wrapper, source-level scanner with Zod schema support, and a `<WebMCPScript />` component for instant `navigator.modelContext` registration.
 - [WebMCP Widget Library](https://webmcp.dev) - One-line `<script>` tag for quick demos and prototyping. [GitHub](https://github.com/jasonjmcghee/WebMCP).
 
 ---


### PR DESCRIPTION
## Summary

- Adds [webmcp-next](https://github.com/dankelleher/next-webmcp) to the Standalone Libraries section
- webmcp-next is a Next.js plugin that auto-exposes API routes and server actions as WebMCP tools and resources with zero config

## Details

webmcp-next wraps `next.config.ts` with `withWebMCP()`, scans source files to auto-discover API routes and server actions, and registers them via a `<WebMCPScript />` component. Supports Zod schemas, next-safe-action, and works with both Turbopack and webpack.