### PR TITLE
Add Agent Ready to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
+- [Agent Ready](https://agent-ready.dev) - Live site that scores any URL 0–100 for AI-agent readability and exposes its own WebMCP tools (`scan_site`, `get_scan`, `ask`) via `navigator.modelContext`, so in-browser agents can run scans without scraping.
 
 ---
 


### PR DESCRIPTION
Adds [agent-ready.dev](https://agent-ready.dev) to the list.

**Why it fits:** agent-ready.dev is a live site that implements WebMCP — it registers its own tools (`scan_site`, `get_scan`, `ask`) on `navigator.modelContext` (feature-detected, no-op where unsupported), so in-browser agents can scan any public URL for AI-agent readability and get back a 0–100 score with per-check fixes. It scores sites against the Vercel Agent Readability Spec, llmstxt.org, and agent-protocol manifests.

- Single entry, follows the existing format in the section.
- Public, free to use, no signup required to scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)