### PR TITLE
Add Scholar Sidekick to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
+- [Scholar Sidekick](https://scholar-sidekick.com) - Citation resolver, formatter, and fabrication checker that registers six WebMCP tools (`resolveIdentifier`, `formatCitation`, `exportCitation`, `verifyCitation`, `checkRetraction`, `checkOpenAccess`) on `navigator.modelContext`, so in-browser agents can resolve DOIs/PMIDs/arXiv IDs, format citations in 10,000+ styles, and check retraction, open-access, and fabrication status without scraping.
 
 ---
 


### PR DESCRIPTION
Adds [Scholar Sidekick](https://scholar-sidekick.com) to the list.

**Why it fits:** Scholar Sidekick is a live site that implements WebMCP — it registers six tools (`resolveIdentifier`, `formatCitation`, `exportCitation`, `verifyCitation`, `checkRetraction`, `checkOpenAccess`) on `navigator.modelContext` (feature-detected via an inline script, no-op where unsupported), so in-browser agents can resolve scholarly identifiers (DOI, PMID, PMCID, ISBN, arXiv, ISSN, ADS bibcode), format citations in 10,000+ CSL styles, export bibliographies, and check retraction, open-access, and citation-fabrication status — without DOM scraping.

- Single entry, follows the existing format in the section.
- Public, free to use, no signup required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)