### PR TITLE
Add agentk (Standalone Libraries) and Stacktree (Community Demos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The official companion library suite for WebMCP.
 
 ### Standalone Libraries
 
-- [agentk](https://github.com/stevysmith/agentk) - Command palette library (cmdk fork) where tools defined once as JSON Schema become auto-generated human forms AND WebMCP registrations. Handles the `navigator.modelContext` to `document.modelContext` move, AbortSignal unregistration, and React StrictMode races. Powers the production deployment at [stacktr.ee](https://stacktr.ee). npm `@stevysmith/agentk`.
+- [agentk](https://github.com/stevysmith/agentk) - React command palette forked from cmdk: describe your app's capabilities once as JSON Schema tools, and the palette auto-generates their parameter forms while the same catalog feeds `registerTool()` so in-browser agents can call whatever humans can. Feature-detects `document.modelContext` (Chrome 150+) with `navigator.modelContext` fallback, polls for the late-arriving origin-trial surface, registers with an `AbortSignal`, and unregisters everything on unmount — no WebMCP just means a plain palette. Optional agent mode plans tool calls via Anthropic, OpenAI, or Gemini behind an opt-in approval screen. Runs in production on [stacktr.ee](https://stacktr.ee); npm `@stevysmith/agentk`, [live demo](https://agentk.stacktr.ee).
 - [Persona](https://github.com/runtypelabs/persona) - The world's first WebMCP-native AI chat UI. A framework-agnostic (vanilla JS), MIT-licensed chat widget you drop into any existing site — React, Vue, a legacy CMS, or static HTML — that discovers and executes WebMCP tools on the parent page, so you can build "copilot" experiences by hooking into your app's existing functionality instead of standing up bespoke agent APIs. Config-driven theming, built-in polyfills. npm `@runtypelabs/persona`, [live demo](https://www.persona-chat.dev/webmcp-slides.html).
 - [webmcp-react](https://github.com/MCPCat/webmcp-react) - React hooks for exposing typed tools via `navigator.modelContext`. Zod-first schemas, built-in polyfill, SSR-compatible (Next.js/Remix), and StrictMode-safe with reactive execution state tracking.
 - [webmcp-kit](https://github.com/victorhuangwq/webmcp-kit) - Zod-typed tool definitions, ideal for modern TypeScript/React apps.
@@ -107,7 +107,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 ### Community Demos
 
-- [Stacktree dashboard](https://stacktr.ee) - Production SaaS (agent-first HTML hosting): the dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP, one shared catalog between the human command palette and in-browser agents. Chrome origin trial registered.
+- [Stacktree dashboard](https://stacktr.ee) - Production SaaS dashboard where one agentk tool catalog serves both the Cmd-K palette for humans and WebMCP registrations for in-browser agents — the same site-management tools (publish, update, gate) either way.
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The official companion library suite for WebMCP.
 
 ### Standalone Libraries
 
+- [agentk](https://github.com/stevysmith/agentk) - Command palette library (cmdk fork) where tools defined once as JSON Schema become auto-generated human forms AND WebMCP registrations. Handles the `navigator.modelContext` to `document.modelContext` move, AbortSignal unregistration, and React StrictMode races. Powers the production deployment at [stacktr.ee](https://stacktr.ee). npm `@stevysmith/agentk`.
 - [Persona](https://github.com/runtypelabs/persona) - The world's first WebMCP-native AI chat UI. A framework-agnostic (vanilla JS), MIT-licensed chat widget you drop into any existing site — React, Vue, a legacy CMS, or static HTML — that discovers and executes WebMCP tools on the parent page, so you can build "copilot" experiences by hooking into your app's existing functionality instead of standing up bespoke agent APIs. Config-driven theming, built-in polyfills. npm `@runtypelabs/persona`, [live demo](https://www.persona-chat.dev/webmcp-slides.html).
 - [webmcp-react](https://github.com/MCPCat/webmcp-react) - React hooks for exposing typed tools via `navigator.modelContext`. Zod-first schemas, built-in polyfill, SSR-compatible (Next.js/Remix), and StrictMode-safe with reactive execution state tracking.
 - [webmcp-kit](https://github.com/victorhuangwq/webmcp-kit) - Zod-typed tool definitions, ideal for modern TypeScript/React apps.
@@ -106,6 +107,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 ### Community Demos
 
+- [Stacktree dashboard](https://stacktr.ee) - Production SaaS (agent-first HTML hosting): the dashboard and docs expose site-management tools (publish, update, gate, share) over WebMCP, one shared catalog between the human command palette and in-browser agents. Chrome origin trial registered.
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.


### PR DESCRIPTION
Adds two entries:

**Standalone Libraries — agentk.** A command palette library I built and run in production. It forks cmdk and adds a tool layer: describe your app's capabilities once as JSON Schema, and that single catalog yields auto-generated parameter forms for humans and `registerTool()` calls for agents. It handles the origin-trial realities — the `navigator.modelContext` → `document.modelContext` move at Chrome 150, surfaces that arrive after mount, `AbortSignal` + unregister cleanup on unmount — and degrades to a plain palette where WebMCP is absent. MIT, npm `@stevysmith/agentk`, live demo at https://agentk.stacktr.ee.

**Community Demos — Stacktree.** My product's dashboard, running the same agentk catalog in production — the site-management tools (publish, update, gate) are reachable through the Cmd-K palette and over the WebMCP surface alike.

Happy to trim, or to split the demo entry out if you'd rather take just the library line.