### PR TITLE
Add admintoolkit.io to Developer Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WordLift AI Readiness Audit](https://audit.wordlift.io/) - Scan your site for WebMCP / agent readiness.
 - [WebMCP Cheat Sheet](https://www.webfuse.com/webmcp-cheat-sheet) - Quick-reference cheat sheet for declarative and imperative APIs, schemas, and common patterns.
 - [webmcpify](https://github.com/TueJon/webmcpify) - Agent skill for Claude Code, Codex, Cursor, and 70+ other coding agents that makes an existing app agent-ready end to end: inventory → approved tool manifest → integrate → verify every tool in a real browser → heal. Vendored zero-dependency runtime, resumable runs.
+- [admintoolkit.io](https://admintoolkit.io/) - A suite of 24 read-only WebMCP tools for infrastructure diagnostics, including a WebMCP tool validator.
 
 ---
 


### PR DESCRIPTION
Adds [admintoolkit.io](https://admintoolkit.io/) to Developer Tools & Utilities.

admintoolkit.io provides 24 read-only WebMCP tools for infrastructure diagnostics, including a [WebMCP tool validator](https://admintoolkit.io/webmcp-tool-validator/).

Validation: confirmed the live tool manifest exposes 24 tools with `readOnlyHint: true`. The change is scoped to one README.md entry.
