### PR TITLE
Add QR Code Crafter to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
+- [QR Code Crafter](https://qrcodecrafter.com/?webmcp=on) - Static QR generator with declarative forms and runtime tools; generation runs locally in the browser without an account.
 
 ---
 


### PR DESCRIPTION
Adds [QR Code Crafter's QR Readability Lab](https://qrcodecrafter.com/qr-code-readability-lab) as a live Community Demo.

The distinctive `generate_verified_qr` WebMCP workflow generates an SVG, PNG, JPG, or WebP asset, performs structural checks, decodes the final asset with a software decoder, and hash-compares the decoded payload with the request. A decode failure or payload mismatch returns a complete failure receipt but no asset bytes.

The workflow is exposed through both a runtime WebMCP tool and a declarative form, requires no account, and is live in production. The PR is intentionally limited to one neutral README entry.

Affiliation disclosure: I am submitting this on behalf of Brand Aspect Ltd, which operates QR Code Crafter.
