### PR TITLE
Correct the `ask` tool description on the Agent Ready entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
 - [Scholar Sidekick](https://scholar-sidekick.com) - Citation resolver and fabrication checker that registers six WebMCP tools on `navigator.modelContext` to resolve DOIs/PMIDs/arXiv IDs, format 10,000+ citation styles, and check retraction and open-access status without scraping.
 - [QR Code Crafter](https://qrcodecrafter.com/qr-code-readability-lab) - Agent-native QR generation that verifies its own output: every SVG, PNG, JPG, or WebP export is decoded back and hash-checked against the requested payload, and a mismatch returns a failure receipt instead of the file.
-- [Agent Ready](https://agent-ready.dev) - Scores any URL 0-100 for agent readability and returns the full structured result to the agent via `scan_site` / `get_scan`, plus an `ask` tool for natural-language search over the scanned site.
+- [Agent Ready](https://agent-ready.dev) - Scores any URL 0-100 for agent readability and returns the full structured result to the agent via `scan_site` / `get_scan`, plus an `ask` tool for natural-language search over Agent Ready's own scoring methodology, check registry, and validated specs.
 
 ---
 


### PR DESCRIPTION
Thanks for merging #6 — one small factual fix to the entry.

The merged line describes `ask` as "natural-language search over the scanned site". It actually searches **Agent Ready's own** content: the scoring methodology, the check registry, the specs it validates, and the explainer/comparison/glossary library. It's the "how does this check work and why did I fail it" tool, not a per-site Q&A tool — someone calling it after a scan expecting answers about *their* site would get our methodology docs instead.

One line, no other changes:

> plus an `ask` tool for natural-language search over Agent Ready's own scoring methodology, check registry, and validated specs.

Happy to shorten if it runs long for the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)