### PR TITLE
Add Agent QA to the related MCP ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 **WebMCP pairs with full MCP clients (Claude Desktop, Cursor, etc.) via relays for end-to-end agent workflows.**
 
+- [Agent QA](https://github.com/vostride/agent-qa) - The self-improving QA agent for software teams, with natural-language web and mobile tests exposed through MCP, CLI, and portable agent skills.
 - [Model Context Protocol](https://modelcontextprotocol.io/) - Official MCP spec, SDKs, and quickstart guides.
 - [MCP-B Desktop Agent Relay](https://docs.mcp-b.ai/tutorials) - Connect desktop MCP agents to in-browser WebMCP tools.
 


### PR DESCRIPTION
## Summary

Adds [Agent QA](https://github.com/vostride/agent-qa) to the explicitly separate **Related: MCP Ecosystem** section.

Agent QA is the self-improving QA agent for software teams. It runs natural-language web and mobile tests and exposes its workflow through an MCP server (`agent-qa mcp`), CLI, and three portable agent skills.

The placement is intentionally in the related MCP section rather than the WebMCP libraries or tools sections: Agent QA is a standard MCP integration and does not claim to implement the browser-side `navigator.modelContext` WebMCP API.

## Checks

- Confirmed the repository and documentation links resolve.
- Preserved the existing one-line list format.
- `git diff --check` passes.

Disclosure: I am affiliated with Agent QA and Vostride.