### PR TITLE
Add WebMCP Kit and WindTunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [📦 Libraries, SDKs & Polyfills](#-libraries-sdks--polyfills)
 - [🎮 Demos & Example Projects](#-demos--example-projects)
 - [🔧 Developer Tools & Utilities](#-developer-tools--utilities)
+- [🧪 Benchmarks & Evaluation](#-benchmarks--evaluation)
 - [🎬 Videos & Talks](#-videos--talks)
 - [📝 Articles & Best Practices](#-articles--best-practices)
 - [👥 Community & Contributing](#-community--contributing)
@@ -126,8 +127,15 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WordLift AI Readiness Audit](https://audit.wordlift.io/) - Scan your site for WebMCP / agent readiness.
 - [WebMCP Tool Validator](https://admintoolkit.io/webmcp-tool-validator/) - Validates WebMCP tool registrations and schemas in the browser. Part of a wider suite of read-only diagnostic tools on admintoolkit.io.
 - [WebMCP Cheat Sheet](https://www.webfuse.com/webmcp-cheat-sheet) - Quick-reference cheat sheet for declarative and imperative APIs, schemas, and common patterns.
+- [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) - Plugin for coding agents with an interactive visual Explorer that maps a site's user journeys to proposed WebMCP tools for review and approval, then implements and verifies them in a real browser.
 - [webmcpify](https://github.com/TueJon/webmcpify) - Agent skill for Claude Code, Codex, Cursor, and 70+ other coding agents that makes an existing app agent-ready end to end: inventory → approved tool manifest → integrate → verify every tool in a real browser → heal. Vendored zero-dependency runtime, resumable runs.
 - [webmaxru/web-ai-agent-skills: WebMCP](https://github.com/webmaxru/web-ai-agent-skills/tree/main/skills/webmcp) - Agent skill for shipping and debugging `navigator.modelContext` integrations in existing JS/TS apps, with guidance for declarative forms, tool schemas, and preview validation.
+
+---
+
+## 🧪 Benchmarks & Evaluation
+
+- [WindTunnel](https://github.com/nekuda-ai/WindTunnel) - Open-source benchmark comparing WebMCP with other browser-agent interfaces across task success, execution time, token usage, and cost.
 
 ---
 


### PR DESCRIPTION
Adds two open-source WebMCP resources:

- **WebMCP Kit** under Developer Tools & Utilities, highlighting its visual Explorer and coding-agent workflow
- **WindTunnel** under a new Benchmarks & Evaluation section

Both links were verified successfully.