### PR TITLE
Add Orbilo to Developer Tools & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [GoogleChromeLabs/webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) - Official toolkit: Model Context Tool Inspector extension, CLI utilities, and demo suite.
 - [WebMCP Inspector](https://webmcpinspector.com/) - Online inspector for testing and debugging WebMCP tool registrations.
 - [WordLift AI Readiness Audit](https://audit.wordlift.io/) - Scan your site for WebMCP / agent readiness.
+- [Orbilo](https://orbilo.co) - Agent readiness checker for UCP and WebMCP. Scores whether in-browser agents can discover and act on your site, then monitors daily as both specs change.
 - [WebMCP Tool Validator](https://admintoolkit.io/webmcp-tool-validator/) - Validates WebMCP tool registrations and schemas in the browser. Part of a wider suite of read-only diagnostic tools on admintoolkit.io.
 - [WebMCP Cheat Sheet](https://www.webfuse.com/webmcp-cheat-sheet) - Quick-reference cheat sheet for declarative and imperative APIs, schemas, and common patterns.
 - [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) - Plugin for coding agents with an interactive visual Explorer that maps a site's user journeys to proposed WebMCP tools for review and approval, then implements and verifies them in a real browser.


### PR DESCRIPTION
Adds Orbilo to Developer Tools & Utilities.

Orbilo is an agent readiness checker for UCP and WebMCP. It scores whether
in-browser agents can discover and act on your site, then monitors daily as
both specs change. Free for one site, no account needed to run a check.

Placed next to the WordLift AI Readiness Audit entry, as it addresses the
same need.

Disclosure: I work on Orbilo.