### PR TITLE
Update Scholar Sidekick entry: seven tools, direct WebMCP page

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [WebMCP Blackjack](https://webmcp-blackjack.heejae.dev) - Multi-agent blackjack game.
 - [Excalidraw + WebMCP](https://shidh.in/demo/webmcp-excalidraw) - Diagram generation driven by AI agents.
 - [Architecture Flow Builder](https://webmcp-flow.vercel.app) - Visual architecture diagramming with agent assistance.
-- [Scholar Sidekick](https://scholar-sidekick.com) - Citation resolver and fabrication checker that registers six WebMCP tools on `navigator.modelContext` to resolve DOIs/PMIDs/arXiv IDs, format 10,000+ citation styles, and check retraction and open-access status without scraping.
+- [Scholar Sidekick](https://scholar-sidekick.com/integrations/webmcp) - Citation resolver and fabrication checker that registers seven WebMCP tools on `navigator.modelContext` to resolve DOIs/PMIDs/arXiv IDs, format 10,000+ citation styles, audit a whole bibliography in one call, and check retraction and open-access status without scraping.
 - [QR Code Crafter](https://qrcodecrafter.com/qr-code-readability-lab) - Agent-native QR generation that verifies its own output: every SVG, PNG, JPG, or WebP export is decoded back and hash-checked against the requested payload, and a mismatch returns a failure receipt instead of the file.
 - [Agent Ready](https://agent-ready.dev) - Scores any URL 0-100 for agent readability and returns the full structured result to the agent via `scan_site` / `get_scan`, plus an `ask` tool for natural-language search over the scanned site.
 


### PR DESCRIPTION
Follow-up to #7, correcting our own entry.

**The tool count is wrong — seven, not six.** `auditBibliography` (audits a whole bibliography in one call — BibTeX, RIS, or CSL-JSON — returning a per-entry verdict plus a corpus summary) shipped after I submitted that PR, and I missed it. My error, not an editing one.

**The link now points at a dedicated WebMCP page** rather than the homepage: <https://scholar-sidekick.com/integrations/webmcp> — what the seven tools do, how registration works, and what it deliberately does not do.

Kept to the single-line house style you trimmed the original entry to. One line changed, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)