### PR TITLE
Add Simple Tools under Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [Scholar Sidekick](https://scholar-sidekick.com/integrations/webmcp) - Citation resolver and fabrication checker that registers seven WebMCP tools on `navigator.modelContext` to resolve DOIs/PMIDs/arXiv IDs, format 10,000+ citation styles, audit a whole bibliography in one call, and check retraction and open-access status without scraping.
 - [QR Code Crafter](https://qrcodecrafter.com/qr-code-readability-lab) - Agent-native QR generation that verifies its own output: every SVG, PNG, JPG, or WebP export is decoded back and hash-checked against the requested payload, and a mismatch returns a failure receipt instead of the file.
 - [Agent Ready](https://agent-ready.dev) - Scores any URL 0-100 for agent readability and returns the full structured result to the agent via `scan_site` / `get_scan`, plus an `ask` tool for natural-language search over Agent Ready's own scoring methodology, check registry, and validated specs.
+- [Simple Tools](https://simpletoolstack.com) - A toolbox for people and agents (PDF, image, text, and more), exposed over WebMCP via `document.modelContext`. Home registers `discover_tools`; each tool page registers its execute tool. [Developers](https://simpletoolstack.com/developers).
 
 ---
 


### PR DESCRIPTION
## Summary
Adds [Simple Tools](https://simpletoolstack.com) under Community Demos.

Simple Tools is a toolbox for people and agents (PDF, image, text, and more). Tools are exposed over WebMCP via `document.modelContext`: the homepage registers `discover_tools`, and each tool page registers its execute tool. Docs: https://simpletoolstack.com/developers

## Checklist
- [x] Follows existing README list style
- [x] Links to a live public site with on-page WebMCP docs