### PR TITLE
Add GunsNation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [Scholar Sidekick](https://scholar-sidekick.com) - Citation resolver and fabrication checker that registers six WebMCP tools on `navigator.modelContext` to resolve DOIs/PMIDs/arXiv IDs, format 10,000+ citation styles, and check retraction and open-access status without scraping.
 - [QR Code Crafter](https://qrcodecrafter.com/qr-code-readability-lab) - Agent-native QR generation that verifies its own output: every SVG, PNG, JPG, or WebP export is decoded back and hash-checked against the requested payload, and a mismatch returns a failure receipt instead of the file.
 - [Agent Ready](https://agent-ready.dev) - Scores any URL 0-100 for agent readability and returns the full structured result to the agent via `scan_site` / `get_scan`, plus an `ask` tool for natural-language search over the scanned site.
+- [GunsNation](https://gunsnation.com) - Firearms price-comparison catalog. Registers five WebMCP tools on `document.modelContext` (with a `navigator.modelContext` fallback): `search_firearms` and `get_firearm` for read-only catalog search and lookup, and `add_to_compare`, `remove_from_compare`, and `list_compare` to drive the site's compare tray.
 
 ---
 


### PR DESCRIPTION
GunsNation (https://gunsnation.com) is a firearms price-comparison catalog that lets shoppers compare prices, specs, and reviews across retailers. Every page registers five WebMCP tools on `document.modelContext` (with a `navigator.modelContext` fallback): `search_firearms` and `get_firearm` for read-only catalog search and lookup, and `add_to_compare`, `remove_from_compare`, and `list_compare` to drive the site's compare tray. The origin trial token is live on the site.

To verify: open https://gunsnation.com in Chrome 149+ with the WebMCP origin trial active, or with `chrome://flags/#enable-webmcp-testing` turned on, and call `document.modelContext.getTools()` from the console.
