### PR TITLE
Add scvd.store to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 ### Community Demos
 
 - [Settled Estate](https://settledestate.com/webmcp/) - Public probate and estate-guidance search, dated comparisons of five reviewed will makers, and state executor-compensation calculators. Browser WebMCP tools update the same visible controls used manually, with source dates, price conditions and explicit unknowns. Financial inputs stay out of shared URLs.
-
+- [scvd.store](https://scvd.store) - Evidence observatory for agentic commerce: a live x402 general store whose free conformance-check and endpoint-preflight instruments (`read_store_guide`, `preflight_endpoint`, `check_conformance`, `verify_artifact`) are also registered read-only via `navigator.modelContext`, alongside the store's own funded x402 payment flow.
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
 - [isainative.dev](https://isainative.dev/) - Scores a public GitHub repository for AI-coding readiness, auditing the codebase rather than the live site. Ships a declarative scan form alongside imperative tool registration.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.


### PR DESCRIPTION
## What

Adds scvd.store to Community Demos: a live x402 general store for AI agents with a parallel WebMCP surface.

## Why it fits

Four read-only tools registered via `navigator.modelContext`:
- `read_store_guide` - the store's machine-readable guide/menu
- `preflight_endpoint` - free pre-payment simulation of any x402 endpoint's client-selection logic
- `check_conformance` - free x402 v2 conformance checking against any issuer's signed offers/receipts, including competitors'
- `verify_artifact` - independent verification of a signed certificate against the store's published key

This is a live production site (not a demo), and the tools are deliberately read-only by design - the store's separate, funded x402 payment path is where money actually moves.

## Checklist

- [x] Live site, tested and working
- [x] One link, one PR
- [x] Description ends with a period, no promotional language
