### PR TITLE
docs: add DeepDeck WebMCP desktop client

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 ## 🔧 Developer Tools & Utilities
 
+- [DeepDeck](https://github.com/jo32/DeepDeck) - MIT-licensed macOS desktop client based on DeepSeek Harness that discovers and calls website-provided WebMCP tools. Its Builder lets an agent explore a site, generate and verify tools, and save versioned source per site for reuse in the DeepDeck browser.
 - [GoogleChromeLabs/webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) - Official toolkit: Model Context Tool Inspector extension, CLI utilities, and demo suite.
 - [WebMCP Inspector](https://webmcpinspector.com/) - Online inspector for testing and debugging WebMCP tool registrations.
 - [WordLift AI Readiness Audit](https://audit.wordlift.io/) - Scan your site for WebMCP / agent readiness.


### PR DESCRIPTION
Adds DeepDeck to the Developer Tools & Utilities section. DeepDeck is an MIT-licensed macOS desktop client built on DeepSeek Harness, with a WebMCP consumer and a Builder that explores pages, verifies operations, and stores tool source and versions per site. Generated tools run in the DeepDeck browser and are shown separately from website-provided tools.

I maintain DeepDeck. The [illustrated walkthrough](https://github.com/deepseek-ai/deepseek-harness/discussions/5856) shows discovery of a website tool, creation of 23 tools for X, and use of a tool to fill a draft. The draft example does not publish a post. The entry makes no benchmark or general compatibility claims.

Validation: checked the existing list for duplicate entries, verified the project and walkthrough links, and ran `git diff --check`.
