### PR TITLE
Add Settled Estate browser WebMCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 ### Community Demos
 
+- [Settled Estate](https://settledestate.com/webmcp/) - Public probate and estate-guidance search, dated comparisons of five reviewed will makers, and state executor-compensation calculators. Browser WebMCP tools update the same visible controls used manually, with source dates, price conditions and explicit unknowns. Financial inputs stay out of shared URLs.
+
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
 - [isainative.dev](https://isainative.dev/) - Scores a public GitHub repository for AI-coding readiness, auditing the codebase rather than the live site. Ships a declarative scan form alongside imperative tool registration.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.


### PR DESCRIPTION
Adds Settled Estate to the live websites/examples list. I maintain the site.

The production integration uses Chrome's current `document.modelContext` API. Three site-wide entry points search public guidance, compare five reviewed will makers, and open a state calculator; `estimate_executor_pay` is registered on the 40 published state calculator pages. The tools reuse the manual UI and business rules and show results before completing. Source dates, billing conditions, editorial provenance and unknown values stay explicit.

- Documentation and manual entry points: https://settledestate.com/webmcp/
- Generated definitions (documentation, not a remote endpoint): https://settledestate.com/webmcp-tools.json
- Example prompt: “Find Pennsylvania guides about letters testamentary.”
- Another example: “Compare FreeWill and Trust & Will.”

This is experimental browser WebMCP, requiring an enabled compatible browser. It is general information, not legal advice. No account, model API or purchase is needed to run the site tools.

Production checks on September 8, 2026 used Chrome 152’s real native API: all 17 browser journey checks and all 40 calculator schemas passed. Six mobile UI surfaces had zero axe WCAG A/AA violations. Inputs, page navigation, source/price conditions and agreement with the visible UI were checked. These are deterministic browser checks, not a model benchmark.
