### PR TITLE
Add Haul Handbook trucking reference and browser tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 
 ### Community Demos
 
+- [Haul Handbook](https://www.haulhandbook.com/) - Trucking reference with four native browser WebMCP tools for site search, navigation, load-dimension comparisons across 51 U.S. jurisdictions, and sourced IFTA fuel-tax rate lookup. Tools update visible controls and preserve source dates and unknown rates. Tested in Chrome 153 with WebMCP enabled.
+
 - [Air Bird Booking](https://github.com/hugozanini/air-bird-booking-web-mcp) - Agent-native flight + accommodation booking. 10x fewer tokens than DOM scraping.
 - [isainative.dev](https://isainative.dev/) - Scores a public GitHub repository for AI-coding readiness, auditing the codebase rather than the live site. Ships a declarative scan form alongside imperative tool registration.
 - [Shoe Store](https://andreinwald.github.io/webmcp-demo) - React e-commerce storefront with full WebMCP integration.


### PR DESCRIPTION
Adds Haul Handbook, a live trucking reference with native `document.modelContext` tools.

- Global: `search_site` and `open_site_page`.
- [Load dimensions](https://www.haulhandbook.com/tools/oversize-permit-cost-estimator/): `check_load_dimensions` compares width and height against published state limits and returns sourced base-fee references; it does not provide route clearance or a full permit quote.
- [IFTA rates](https://www.haulhandbook.com/tools/ifta-tax-rates/): `browse_ifta_rates` filters the published rate table by fuel, country, and page, preserving missing rates and separate surcharges.

These tools use the same visible controls as manual visitors. Experimental browser support: native Chrome 153 with WebMCP enabled; callbacks without cancellation signals fail before changing the page. Production native discovery and execution verified after deployment.
