### PR TITLE
Add Timeline Studio to Community Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ From the [webmcp-tools](https://github.com/GoogleChromeLabs/webmcp-tools) repo:
 - [Simple Tools](https://simpletoolstack.com) - A toolbox for people and agents (PDF, image, text, and more), exposed over WebMCP via `document.modelContext`. Home registers `discover_tools`; each tool page registers its execute tool. [Developers](https://simpletoolstack.com/developers).
 - [scvd.store](https://scvd.store) - Evidence observatory for agentic commerce: a live x402 general store whose free conformance-check and endpoint-preflight instruments (`read_store_guide`, `preflight_endpoint`, `check_conformance`, `verify_artifact`) are also registered read-only via `navigator.modelContext`, alongside the store's own funded x402 payment flow.
 - [Settled Estate](https://settledestate.com/webmcp/) - Public probate and estate-guidance search, dated comparisons of five reviewed will makers, and state executor-compensation calculators. Browser WebMCP tools update the same visible controls used manually, with source dates, price conditions and explicit unknowns. Financial inputs stay out of shared URLs.
+- [Timeline Studio](https://video-editor.ai-creator.top/) - Open-source browser video editor exposing nine WebMCP tools for timeline inspection, previewed clip reordering and basic trimming, guarded undo, and editable project downloads. [GitHub](https://github.com/MartinDelophy/ai-video-editor) · [Docs](https://github.com/MartinDelophy/ai-video-editor/blob/v1.0.8/docs/webmcp.md).
 
 ---
 


### PR DESCRIPTION
Adds Timeline Studio to **Demos & Example Projects → Community Demos**, with links to the live editor, source code, and versioned WebMCP documentation.

Timeline Studio exposes the project open in the browser through nine native WebMCP tools. Agents can inspect the timeline, preview and apply supported clip reordering or basic trims, seek the preview, undo an unchanged agent transaction, and download an editable `.timeline` project. Editing uses the existing timeline engine and history, with state checks before apply and undo.

The integration prefers `document.modelContext.registerTool` and supports an existing legacy `navigator.modelContext` implementation. It requires a compatible browser and agent host. Project download does not render a video.

Validation:
- Confirmed the live editor and its published agent documentation are reachable.
- Checked the description against the [v1.0.8 integration guide](https://github.com/MartinDelophy/ai-video-editor/blob/v1.0.8/docs/webmcp.md) and [tool implementation](https://github.com/MartinDelophy/ai-video-editor/blob/v1.0.8/src/lib/webMcpEditor.js).
- The v1.0.8 browser integration was verified with a 10-second project reordered and trimmed to 8 seconds, then restored to 10 seconds through guarded undo.
- This PR changes one README entry only; `git diff --check` passes.

Disclosure: submitted on behalf of the Timeline Studio project maintainer.
